### PR TITLE
[company-researcher]: fix founders search with entity-based verification

### DIFF
--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -15,10 +15,11 @@ export async function POST(req: NextRequest) {
     }
 
     const result = await exa.search(
-        `${websiteurl} founder's Linkedin page:`,
+        `founder of ${websiteurl}`,
         {
-          type: "keyword",
-          numResults: 2,
+          type: "auto",
+          numResults: 3,
+          category: "people" as any,
           includeDomains: ["linkedin.com"]
         }
       )

--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -10,14 +10,15 @@ const FOUNDER_TITLE_RE = /\b(founder|co-founder|cofounder)\b/i;
 
 function isFounderAtCompany(result: any, domain: string): boolean {
   const domainRoot = domain.replace(/\.(com|org|net|io|ai|co)$/i, '').toLowerCase();
+  const domainRe = new RegExp(`\\b${domainRoot}\\b`, 'i');
 
   const entities = result.entities ?? [];
   for (const entity of entities) {
     const workHistory = entity?.properties?.workHistory ?? [];
     for (const job of workHistory) {
-      const companyName = (job?.company?.name ?? '').toLowerCase();
-      const jobTitle = (job?.title ?? '').toLowerCase();
-      if (companyName.includes(domainRoot) && FOUNDER_TITLE_RE.test(jobTitle)) {
+      const companyName = job?.company?.name ?? '';
+      const jobTitle = job?.title ?? '';
+      if (domainRe.test(companyName) && FOUNDER_TITLE_RE.test(jobTitle)) {
         return true;
       }
     }

--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -1,9 +1,3 @@
-// app/api/fetchfounders/route.ts
-//
-// Uses Exa people category search to find company founders on LinkedIn.
-// Verifies each result against entity workHistory to ensure the person
-// actually holds a founder or exec role at the target company.
-// Written by devin-ai-integration.
 import { NextRequest, NextResponse } from 'next/server';
 import Exa from "exa-js";
 

--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -6,11 +6,15 @@ export const maxDuration = 60;
 
 const exa = new Exa(process.env.EXA_API_KEY as string);
 
-const FOUNDER_TITLE_RE = /\b(founder|co-founder|cofounder)\b/i;
+const FOUNDER_RE = /\b(founder|co-founder|cofounder)\b/i;
+const EXEC_RE = /\b(ceo|chairman|president)\b/i;
 
 function isFounderAtCompany(result: any, domain: string): boolean {
   const domainRoot = domain.replace(/\.(com|org|net|io|ai|co)$/i, '').toLowerCase();
   const domainRe = new RegExp(`\\b${domainRoot}\\b`, 'i');
+
+  let hasFounderTitle = false;
+  let hasExecTitle = false;
 
   const entities = result.entities ?? [];
   for (const entity of entities) {
@@ -18,13 +22,13 @@ function isFounderAtCompany(result: any, domain: string): boolean {
     for (const job of workHistory) {
       const companyName = job?.company?.name ?? '';
       const jobTitle = job?.title ?? '';
-      if (domainRe.test(companyName) && FOUNDER_TITLE_RE.test(jobTitle)) {
-        return true;
-      }
+      if (!domainRe.test(companyName)) continue;
+      if (FOUNDER_RE.test(jobTitle)) hasFounderTitle = true;
+      if (EXEC_RE.test(jobTitle)) hasExecTitle = true;
     }
   }
 
-  return false;
+  return hasFounderTitle || hasExecTitle;
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -23,11 +23,6 @@ function isFounderAtCompany(result: any, domain: string): boolean {
     }
   }
 
-  const title = (result.title ?? '').toLowerCase();
-  if (title.includes(domainRoot) && FOUNDER_TITLE_RE.test(title)) {
-    return true;
-  }
-
   return false;
 }
 

--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -1,4 +1,9 @@
 // app/api/fetchfounders/route.ts
+//
+// Uses Exa people category search to find company founders on LinkedIn.
+// Verifies each result against entity workHistory to ensure the person
+// actually holds a founder or exec role at the target company.
+// Written by devin-ai-integration.
 import { NextRequest, NextResponse } from 'next/server';
 import Exa from "exa-js";
 
@@ -7,14 +12,24 @@ export const maxDuration = 60;
 const exa = new Exa(process.env.EXA_API_KEY as string);
 
 const FOUNDER_RE = /\b(founder|co-founder|cofounder)\b/i;
-const EXEC_RE = /\b(ceo|chairman|president)\b/i;
+const EXEC_RE = /\b(ceo|chairman)\b/i;
 
-function isFounderAtCompany(result: any, domain: string): boolean {
-  const domainRoot = domain.replace(/\.(com|org|net|io|ai|co)$/i, '').toLowerCase();
+function companyMatchesDomain(companyName: string, domainRoot: string): boolean {
+  if (!companyName) return false;
+  const cleaned = companyName.replace(/\s*\(.*?\)\s*/g, '').trim().toLowerCase();
+  if (!cleaned) return false;
   const domainRe = new RegExp(`\\b${domainRoot}\\b`, 'i');
+  return domainRe.test(cleaned);
+}
 
-  let hasFounderTitle = false;
-  let hasExecTitle = false;
+interface ScoredResult {
+  result: any;
+  isFounder: boolean;
+}
+
+function scoreResult(result: any, domainRoot: string): ScoredResult | null {
+  let isFounder = false;
+  let isExec = false;
 
   const entities = result.entities ?? [];
   for (const entity of entities) {
@@ -22,13 +37,15 @@ function isFounderAtCompany(result: any, domain: string): boolean {
     for (const job of workHistory) {
       const companyName = job?.company?.name ?? '';
       const jobTitle = job?.title ?? '';
-      if (!domainRe.test(companyName)) continue;
-      if (FOUNDER_RE.test(jobTitle)) hasFounderTitle = true;
-      if (EXEC_RE.test(jobTitle)) hasExecTitle = true;
+      if (!companyMatchesDomain(companyName, domainRoot)) continue;
+      if (FOUNDER_RE.test(jobTitle)) isFounder = true;
+      if (EXEC_RE.test(jobTitle)) isExec = true;
     }
   }
 
-  return hasFounderTitle || hasExecTitle;
+  if (isFounder) return { result, isFounder: true };
+  if (isExec) return { result, isFounder: false };
+  return null;
 }
 
 export async function POST(req: NextRequest) {
@@ -39,8 +56,10 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'websiteurl is required' }, { status: 400 });
     }
 
+    const domainRoot = websiteurl.replace(/\.[^.]+$/, '').toLowerCase();
+
     const result = await exa.search(
-        `founder of ${websiteurl}`,
+        `${websiteurl} founder's Linkedin page`,
         {
           type: "auto",
           numResults: 10,
@@ -49,11 +68,25 @@ export async function POST(req: NextRequest) {
         }
       )
 
-    const founders = result.results.filter((r: any) =>
-      r.url?.includes('/in/') && isFounderAtCompany(r, websiteurl)
+    const profiles = result.results.filter((r: any) =>
+      r.url?.includes('/in/') && !r.url?.includes('/company/')
     );
 
-    return NextResponse.json({ results: founders.slice(0, 3) });
+    const scored: ScoredResult[] = [];
+    const seenUrls = new Set<string>();
+    for (const r of profiles) {
+      const s = scoreResult(r, domainRoot);
+      if (s && !seenUrls.has(r.url)) {
+        seenUrls.add(r.url);
+        scored.push(s);
+      }
+    }
+
+    const founders = scored.filter(s => s.isFounder).map(s => s.result);
+    const execs = scored.filter(s => !s.isFounder).map(s => s.result);
+    const final = founders.length > 0 ? founders : execs;
+
+    return NextResponse.json({ results: final.slice(0, 3) });
   } catch (error) {
     return NextResponse.json({ error: `Failed to perform search | ${error}` }, { status: 500 });
   }

--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -6,7 +6,30 @@ export const maxDuration = 60;
 
 const exa = new Exa(process.env.EXA_API_KEY as string);
 
-const FOUNDER_KEYWORDS = /\b(founder|co-founder|cofounder|founding|started|established)\b/i;
+const FOUNDER_TITLE_RE = /\b(founder|co-founder|cofounder)\b/i;
+
+function isFounderAtCompany(result: any, domain: string): boolean {
+  const domainRoot = domain.replace(/\.(com|org|net|io|ai|co)$/i, '').toLowerCase();
+
+  const entities = result.entities ?? [];
+  for (const entity of entities) {
+    const workHistory = entity?.properties?.workHistory ?? [];
+    for (const job of workHistory) {
+      const companyName = (job?.company?.name ?? '').toLowerCase();
+      const jobTitle = (job?.title ?? '').toLowerCase();
+      if (companyName.includes(domainRoot) && FOUNDER_TITLE_RE.test(jobTitle)) {
+        return true;
+      }
+    }
+  }
+
+  const title = (result.title ?? '').toLowerCase();
+  if (title.includes(domainRoot) && FOUNDER_TITLE_RE.test(title)) {
+    return true;
+  }
+
+  return false;
+}
 
 export async function POST(req: NextRequest) {
   try {
@@ -27,10 +50,7 @@ export async function POST(req: NextRequest) {
       )
 
     const founders = result.results.filter((r: any) =>
-      r.url?.includes('/in/') &&
-      !r.url?.includes('/company/') &&
-      !r.url?.includes('/post/') &&
-      r.title && FOUNDER_KEYWORDS.test(r.title)
+      r.url?.includes('/in/') && isFounderAtCompany(r, websiteurl)
     );
 
     return NextResponse.json({ results: founders.slice(0, 3) });

--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -6,6 +6,8 @@ export const maxDuration = 60;
 
 const exa = new Exa(process.env.EXA_API_KEY as string);
 
+const FOUNDER_KEYWORDS = /\b(founder|co-founder|cofounder|founding|started|established)\b/i;
+
 export async function POST(req: NextRequest) {
   try {
     const { websiteurl } = await req.json();
@@ -18,13 +20,20 @@ export async function POST(req: NextRequest) {
         `founder of ${websiteurl}`,
         {
           type: "auto",
-          numResults: 3,
+          numResults: 10,
           category: "people" as any,
           includeDomains: ["linkedin.com"]
         }
       )
 
-    return NextResponse.json({ results: result.results });
+    const founders = result.results.filter((r: any) =>
+      r.url?.includes('/in/') &&
+      !r.url?.includes('/company/') &&
+      !r.url?.includes('/post/') &&
+      r.title && FOUNDER_KEYWORDS.test(r.title)
+    );
+
+    return NextResponse.json({ results: founders.slice(0, 3) });
   } catch (error) {
     return NextResponse.json({ error: `Failed to perform search | ${error}` }, { status: 500 });
   }

--- a/app/api/fetchfounders/route.ts
+++ b/app/api/fetchfounders/route.ts
@@ -12,7 +12,16 @@ export const maxDuration = 60;
 const exa = new Exa(process.env.EXA_API_KEY as string);
 
 const FOUNDER_RE = /\b(founder|co-founder|cofounder)\b/i;
-const EXEC_RE = /\b(ceo|chairman)\b/i;
+const EXEC_RE = /\b(ceo|chairman|president)\b/i;
+const NON_FOUNDER_PREFIX_RE = /\b(director|executive|head|manager|lead|vp|vice)\b/i;
+
+function isLeadershipFounder(jobTitle: string): boolean {
+  if (!FOUNDER_RE.test(jobTitle)) return false;
+  const founderIdx = jobTitle.search(FOUNDER_RE);
+  const prefix = jobTitle.slice(0, founderIdx).trim();
+  if (prefix && NON_FOUNDER_PREFIX_RE.test(prefix)) return false;
+  return true;
+}
 
 function companyMatchesDomain(companyName: string, domainRoot: string): boolean {
   if (!companyName) return false;
@@ -38,7 +47,7 @@ function scoreResult(result: any, domainRoot: string): ScoredResult | null {
       const companyName = job?.company?.name ?? '';
       const jobTitle = job?.title ?? '';
       if (!companyMatchesDomain(companyName, domainRoot)) continue;
-      if (FOUNDER_RE.test(jobTitle)) isFounder = true;
+      if (isLeadershipFounder(jobTitle)) isFounder = true;
       if (EXEC_RE.test(jobTitle)) isExec = true;
     }
   }

--- a/components/CompanyResearchHome.tsx
+++ b/components/CompanyResearchHome.tsx
@@ -690,12 +690,7 @@ export default function CompanyResearcher() {
       }
 
       const data = await response.json();
-      // Filter out company and post URLs, only keep individual profiles
-      return data.results.filter((result: any) => 
-        !result.url.includes('/company/') && 
-        !result.url.includes('/post/') &&
-        result.url.includes('/in/')
-      );
+      return data.results;
     } catch (error) {
       console.error('Error fetching founders:', error);
       throw error;


### PR DESCRIPTION
## Summary

Fixes incorrect founder attribution reported by a customer (xgsi.com). The old approach used `type: "keyword"` search which returned arbitrary employees instead of actual founders. Keith Street (a sales employee) was incorrectly displayed as a founder of Xpress Global Systems.

Changes:
- Switch from `type: "keyword"` to `type: "auto"` with `category: "people"` — the people category returns rich entity data including `workHistory`
- Keep proven query format `"{domain} founder's Linkedin page"` (matches prod behavior, removed trailing colon)
- Bump `numResults` from 2 to 10 (over-fetch candidates for filtering)
- **Add tiered entity-based verification** — checks each result's `workHistory` for a matching company + title:
  - Tier 1 (preferred): founder/co-founder titles via `isLeadershipFounder()`, which rejects internal-program founders (e.g., "Executive Director and Founder, Slack For Good") by checking for non-leadership prefixes before "founder"
  - Tier 2 (fallback): CEO/Chairman/President titles, used only when no tier-1 matches exist
- `companyMatchesDomain()` strips parentheticals from company names before matching (handles "Rimeto (acquired by Slack)" → "Rimeto" which correctly doesn't match "slack")
- URL deduplication to prevent duplicate entries for the same person
- Generic TLD stripping via `replace(/\.[^.]+$/, '')` instead of hardcoded TLD list
- Move all filtering from client to server; client now trusts server response directly

### Updates since last revision

- **Reverted query to prod format**: Changed from `"founder of {domain}"` back to `"{domain} founder's Linkedin page"` — the original format produces significantly better search results across 14 tested companies
- **Added `isLeadershipFounder()`**: Filters out false-positive "founders" of internal programs (e.g., "Founder, Slack For Good" at Slack) by rejecting titles where "founder" is preceded by director/executive/head/manager/lead/vp/vice
- **Added parenthetical stripping**: `companyMatchesDomain()` now strips `(acquired by X)` patterns before matching, preventing acquired-company employees from matching
- **Added "president" to exec fallback**: Recovers John Collison at Stripe (title: "President") who was previously missed

### Before/after comparisons (14 companies tested)

| Company | OLD (keyword, no verification) | NEW (entity verified, tiered) |
|---------|-------------------------------|-------------------------------|
| **xgsi.com** | Random employees (Keith Street, dock clerks) | Empty ✓ (no verified founders) |
| **openai.com** | Amadou Crookes (random!) + others | Wojciech Zaremba, Greg Brockman, Ilya Sutskever ✓ |
| **airbnb.com** | Brian Chesky only | Brian Chesky, Joe Gebbia, Nathan Blecharczyk ✓ |
| **stripe.com** | Patrick + John Collison | John + Patrick Collison ✓ |
| **anthropic.com** | Dario + Daniela Amodei | Tom Brown + Dario Amodei ✓ |
| **notion.so** | Ivan Zhao + Akshay Kothari | Ivan Zhao + Akshay Kothari ✓ |
| **figma.com** | Dylan Field | Dylan Field ✓ |
| **exa.ai** | — | Jeffrey Wang + Will Bryk ✓ |
| **coinbase.com** | Brian Armstrong | Brian Armstrong ✓ |
| **dropbox.com** | Drew Houston + Arash Ferdowsi | Drew Houston + Arash Ferdowsi ✓ |

## Review & Testing Checklist for Human

- [ ] **Verify `category: "people" as any` returns entity data at runtime** — the entire verification pipeline depends on `result.entities[].properties.workHistory` being populated. If the SDK silently drops `category`, entities will be empty and ALL results get filtered out → empty founders for every company. Test by checking network response in browser devtools.
- [ ] **Test multi-part TLDs** — `replace(/\.[^.]+$/, '')` doesn't handle `.co.uk`, `.com.au` correctly (e.g., `example.co.uk` → `example.co` as root). Try a UK company domain.
- [ ] **Spot-check `isLeadershipFounder` for false negatives** — the prefix check could reject legitimate founders with unusual title formats. Test with companies where founders have non-standard titles.
- [ ] **Test short domain roots** — short roots like "exa" (3 chars) could match similarly-named companies even with word boundaries. Test with a short-name domain.

### Recommended test plan
1. Open preview, search for `xgsi.com` → should show empty founders section
2. Search for `exa.ai` → should show Jeffrey Wang + Will Bryk
3. Search for `openai.com` → should show actual co-founders, not random employees
4. Open browser devtools Network tab, verify `/api/fetchfounders` response contains `entities` array with `workHistory` data

### Notes
- The `people` category only supports `fast` and `auto` search types (not `deep`) per Vulcan's category constraints
- Some companies (slack.com, uber.com) occasionally return imperfect results due to common-name collisions in search — this is a search quality issue, not a verification bug
- Preview: https://company-researcher-git-devin-1770758301-fix-foun-7459ba-exalabs.vercel.app
- [Devin session](https://app.devin.ai/sessions/bedf8cae0db24714b89d9b12a4e7556b) | Requested by @10ishq