### PR TITLE
Move GitHub token out of client bundle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ EXA_API_KEY=your_exa_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
 YOUTUBE_API_KEY=your_youtube_api_key
-NEXT_PUBLIC_GITHUB_TOKEN=your_github_token
+GITHUB_TOKEN=your_github_token
 
 # This is an example file. You need to create a file named .env.local in your project folder and add the API key there. If you are deploying this on a hosting platform like Vercel, you should add it to the 'Environment Variables' in the platform's settings.
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ Create a `.env.local` file in the root directory with the following structure:
 EXA_API_KEY=your_exa_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# Optional - for additional features
+# Optional - for additional features (do not prefix with NEXT_PUBLIC_;
+# GitHub token is used server-side only and must not be exposed to the browser)
 YOUTUBE_API_KEY=your_youtube_api_key
-NEXT_PUBLIC_GITHUB_TOKEN=your_github_token
+GITHUB_TOKEN=your_github_token
 ```
 
 > For deployment on platforms like Vercel, add these environment variables in your platform's settings.

--- a/app/api/github/route.ts
+++ b/app/api/github/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const username = searchParams.get('username');
+
+  if (!username) {
+    return NextResponse.json({ error: 'username is required' }, { status: 400 });
+  }
+
+  const headers: HeadersInit = {
+    Accept: 'application/vnd.github.v3+json',
+    'User-Agent': 'company-researcher',
+  };
+
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const [profileResponse, reposResponse] = await Promise.all([
+      fetch(`https://api.github.com/users/${username}`, { headers }),
+      fetch(
+        `https://api.github.com/users/${username}/repos?sort=stars&direction=desc&per_page=6`,
+        { headers }
+      ),
+    ]);
+
+    if (!profileResponse.ok) {
+      const details = await profileResponse.text();
+      return NextResponse.json(
+        { error: 'Failed to fetch GitHub profile', details },
+        { status: profileResponse.status }
+      );
+    }
+
+    if (!reposResponse.ok) {
+      const details = await reposResponse.text();
+      return NextResponse.json(
+        { error: 'Failed to fetch GitHub repositories', details },
+        { status: reposResponse.status }
+      );
+    }
+
+    const profile = await profileResponse.json();
+    const repositories = await reposResponse.json();
+
+    return NextResponse.json({ ...profile, repositories });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json(
+      { error: `Failed to fetch GitHub data: ${message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/components/github/GitHubDisplay.tsx
+++ b/components/github/GitHubDisplay.tsx
@@ -58,28 +58,12 @@ export default function GitHubDisplay({ githubUrl }: GitHubDisplayProps) {
         const username = githubUrl.split('/').pop();
         if (!username) throw new Error('Invalid GitHub URL');
 
-        const headers = {
-          'Authorization': `Bearer ${process.env.NEXT_PUBLIC_GITHUB_TOKEN}`,
-          'Accept': 'application/vnd.github.v3+json',
-        };
+        // Fetch through the server-side API route so the token stays on the server
+        const response = await fetch(`/api/github?username=${username}`);
+        if (!response.ok) throw new Error('Failed to fetch GitHub data');
+        const data = await response.json();
 
-        // Fetch profile data
-        const profileResponse = await fetch(`https://api.github.com/users/${username}`, { headers });
-        if (!profileResponse.ok) throw new Error('Failed to fetch GitHub profile');
-        const profileData = await profileResponse.json();
-
-        // Fetch repositories with sort parameter in the API URL
-        const reposResponse = await fetch(
-          `https://api.github.com/users/${username}/repos?sort=stars&direction=desc&per_page=6`,
-          { headers }
-        );
-        if (!reposResponse.ok) throw new Error('Failed to fetch repositories');
-        const reposData = await reposResponse.json();
-
-        setProfile({
-          ...profileData,
-          repositories: reposData
-        });
+        setProfile(data);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch GitHub data');
       } finally {


### PR DESCRIPTION
Moves the GitHub PAT out of the Next.js client bundle.

- Added `app/api/github/route.ts` to fetch the GitHub user/repos server-side using `GITHUB_TOKEN`.
- Updated `components/github/GitHubDisplay.tsx` to call the new `/api/github` route.
- Renamed `NEXT_PUBLIC_GITHUB_TOKEN` to `GITHUB_TOKEN` in `.env.example` and `README.md` (server-only).

After merging, update Vercel:
- Remove `NEXT_PUBLIC_GITHUB_TOKEN`
- Add `GITHUB_TOKEN` as a secret
- Re-deploy

This prevents the token from being inlined into the browser JS bundle while preserving the higher authenticated GitHub rate limit.